### PR TITLE
Collect test coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  codecov: codecov/codecov@4.0.1
+
 aliases:
   - &docker
     - image: cimg/openjdk:18.0-node
@@ -336,7 +339,9 @@ jobs:
     steps:
       - checkout
       - setup_node_modules
-      - run: yarn test <<parameters.args>> --ci
+      - run: yarn test <<parameters.args>> --ci --coverage
+      - codecov/upload:
+          flags: source-<<parameters.args>>
 
   yarn_test_build:
     docker: *docker


### PR DESCRIPTION
Main idea is to find uncovered tests due to flags.

Missing:
- add job to test where `@gate` skips instead