### PR TITLE
Reveal fiber tags in fragment traversal helpers and scroll to text siblings

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -62,13 +62,13 @@ import {
   isOwnedInstance,
 } from './ReactDOMComponentTree';
 import {
-  traverseFragmentInstance,
-  getFragmentParentHostFiber,
+  traverseFragmentInstanceHostComponentsAndTexts,
+  getFragmentParentHostComponentOrRootFiber,
   getInstanceFromHostFiber,
   isFiberFollowing,
   isFiberPreceding,
-  getFragmentInstanceSiblings,
-  traverseFragmentInstanceDeeply,
+  getFragmentInstanceHostComponentSiblings,
+  traverseFragmentInstanceHostComponentsAndTextsDeeply,
   fiberIsPortaledIntoHost,
   isFiberContainedByFragment,
   isFragmentContainedByFiber,
@@ -221,6 +221,9 @@ export type Instance = Element;
 export type TextInstance = Text;
 
 type InstanceWithFragmentHandles = Instance & {
+  reactFragments?: Set<FragmentInstanceType>,
+};
+type HostNodeWithFragmentHandles = (Instance | TextInstance) & {
   reactFragments?: Set<FragmentInstanceType>,
 };
 
@@ -3036,7 +3039,7 @@ FragmentInstance.prototype.addEventListener = function (
     indexOfEventListener(listeners, type, listener, optionsOrUseCapture) === -1;
   if (isNewEventListener) {
     listeners.push({type, listener, optionsOrUseCapture});
-    traverseFragmentInstance(
+    traverseFragmentInstanceHostComponentsAndTexts(
       this._fragmentFiber,
       addEventListenerToChild,
       type,
@@ -3052,7 +3055,7 @@ function addEventListenerToChild(
   listener: EventListener,
   optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
 ): boolean {
-  const instance = getInstanceFromHostFiber<Instance>(child);
+  const instance = getInstanceFromHostFiber<Instance | TextInstance>(child);
   instance.addEventListener(type, listener, optionsOrUseCapture);
   return false;
 }
@@ -3068,7 +3071,7 @@ FragmentInstance.prototype.removeEventListener = function (
     return;
   }
   if (typeof listeners !== 'undefined' && listeners.length > 0) {
-    traverseFragmentInstance(
+    traverseFragmentInstanceHostComponentsAndTexts(
       this._fragmentFiber,
       removeEventListenerFromChild,
       type,
@@ -3092,7 +3095,7 @@ function removeEventListenerFromChild(
   listener: EventListener,
   optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
 ): boolean {
-  const instance = getInstanceFromHostFiber<Instance>(child);
+  const instance = getInstanceFromHostFiber<Instance | TextInstance>(child);
   instance.removeEventListener(type, listener, optionsOrUseCapture);
   return false;
 }
@@ -3136,12 +3139,15 @@ FragmentInstance.prototype.dispatchEvent = function (
   this: FragmentInstanceType,
   event: Event,
 ): boolean {
-  const parentHostFiber = getFragmentParentHostFiber(this._fragmentFiber);
+  const parentHostFiber = getFragmentParentHostComponentOrRootFiber(
+    this._fragmentFiber,
+  );
   if (parentHostFiber === null) {
     return true;
   }
-  const parentHostInstance =
-    getInstanceFromHostFiber<Instance>(parentHostFiber);
+  const parentHostInstance = getInstanceFromHostFiber<Instance | Container>(
+    parentHostFiber,
+  );
   const eventListeners = this._eventListeners;
   if (
     (eventListeners !== null && eventListeners.length > 0) ||
@@ -3173,7 +3179,7 @@ FragmentInstance.prototype.focus = function (
   this: FragmentInstanceType,
   focusOptions?: FocusOptions,
 ): void {
-  traverseFragmentInstanceDeeply(
+  traverseFragmentInstanceHostComponentsAndTextsDeeply(
     this._fragmentFiber,
     setFocusOnFiberIfFocusable,
     focusOptions,
@@ -3198,7 +3204,7 @@ FragmentInstance.prototype.focusLast = function (
   focusOptions?: FocusOptions,
 ): void {
   const children: Array<Fiber> = [];
-  traverseFragmentInstanceDeeply(
+  traverseFragmentInstanceHostComponentsAndTextsDeeply(
     this._fragmentFiber,
     collectChildren,
     children,
@@ -3217,18 +3223,21 @@ function collectChildren(child: Fiber, collection: Array<Fiber>): boolean {
 // $FlowFixMe[prop-missing]
 FragmentInstance.prototype.blur = function (this: FragmentInstanceType): void {
   // Early exit if activeElement is not within the fragment's parent
-  const parentHostFiber = getFragmentParentHostFiber(this._fragmentFiber);
+  const parentHostFiber = getFragmentParentHostComponentOrRootFiber(
+    this._fragmentFiber,
+  );
   if (parentHostFiber === null) {
     return;
   }
-  const parentHostInstance =
-    getInstanceFromHostFiber<Instance>(parentHostFiber);
+  const parentHostInstance = getInstanceFromHostFiber<Instance | Container>(
+    parentHostFiber,
+  );
   const activeElement = parentHostInstance.ownerDocument.activeElement;
   if (activeElement === null || !parentHostInstance.contains(activeElement)) {
     return;
   }
 
-  traverseFragmentInstance(
+  traverseFragmentInstanceHostComponentsAndTexts(
     this._fragmentFiber,
     blurActiveElementWithinFragment,
     activeElement,
@@ -3259,16 +3268,19 @@ FragmentInstance.prototype.observeUsing = function (
     if (enableFragmentRefsTextNodes) {
       let hasText = false;
       let hasElement = false;
-      traverseFragmentInstance(this._fragmentFiber, (child: Fiber) => {
-        if (child.tag === HostText) {
-          hasText = true;
-        } else {
-          // Stop traversal, found element
-          hasElement = true;
-          return true;
-        }
-        return false;
-      });
+      traverseFragmentInstanceHostComponentsAndTexts(
+        this._fragmentFiber,
+        (child: Fiber) => {
+          if (child.tag === HostText) {
+            hasText = true;
+          } else {
+            // Stop traversal, found element
+            hasElement = true;
+            return true;
+          }
+          return false;
+        },
+      );
       if (hasText && !hasElement) {
         console.error(
           'observeUsing() was called on a FragmentInstance with only text children. ' +
@@ -3281,7 +3293,11 @@ FragmentInstance.prototype.observeUsing = function (
     this._observers = new Set();
   }
   this._observers.add(observer);
-  traverseFragmentInstance(this._fragmentFiber, observeChild, observer);
+  traverseFragmentInstanceHostComponentsAndTexts(
+    this._fragmentFiber,
+    observeChild,
+    observer,
+  );
 };
 function observeChild(
   child: Fiber,
@@ -3312,7 +3328,11 @@ FragmentInstance.prototype.unobserveUsing = function (
     }
   } else {
     observers.delete(observer);
-    traverseFragmentInstance(this._fragmentFiber, unobserveChild, observer);
+    traverseFragmentInstanceHostComponentsAndTexts(
+      this._fragmentFiber,
+      unobserveChild,
+      observer,
+    );
   }
 };
 function unobserveChild(
@@ -3334,7 +3354,11 @@ FragmentInstance.prototype.getClientRects = function (
   this: FragmentInstanceType,
 ): Array<DOMRect> {
   const rects: Array<DOMRect> = [];
-  traverseFragmentInstance(this._fragmentFiber, collectClientRects, rects);
+  traverseFragmentInstanceHostComponentsAndTexts(
+    this._fragmentFiber,
+    collectClientRects,
+    rects,
+  );
   return rects;
 };
 function collectClientRects(child: Fiber, rects: Array<DOMRect>): boolean {
@@ -3356,12 +3380,15 @@ FragmentInstance.prototype.getRootNode = function (
   this: FragmentInstanceType,
   getRootNodeOptions?: {composed: boolean},
 ): Document | ShadowRoot | FragmentInstanceType {
-  const parentHostFiber = getFragmentParentHostFiber(this._fragmentFiber);
+  const parentHostFiber = getFragmentParentHostComponentOrRootFiber(
+    this._fragmentFiber,
+  );
   if (parentHostFiber === null) {
     return this;
   }
-  const parentHostInstance =
-    getInstanceFromHostFiber<Instance>(parentHostFiber);
+  const parentHostInstance = getInstanceFromHostFiber<Instance | Container>(
+    parentHostFiber,
+  );
   const rootNode =
     // $FlowFixMe[incompatible-type] Flow expects Node
     parentHostInstance.getRootNode(getRootNodeOptions) as Document | ShadowRoot;
@@ -3372,14 +3399,21 @@ FragmentInstance.prototype.compareDocumentPosition = function (
   this: FragmentInstanceType,
   otherNode: Instance,
 ): number {
-  const parentHostFiber = getFragmentParentHostFiber(this._fragmentFiber);
+  const parentHostFiber = getFragmentParentHostComponentOrRootFiber(
+    this._fragmentFiber,
+  );
   if (parentHostFiber === null) {
     return Node.DOCUMENT_POSITION_DISCONNECTED;
   }
   const children: Array<Fiber> = [];
-  traverseFragmentInstance(this._fragmentFiber, collectChildren, children);
-  const parentHostInstance =
-    getInstanceFromHostFiber<Instance>(parentHostFiber);
+  traverseFragmentInstanceHostComponentsAndTexts(
+    this._fragmentFiber,
+    collectChildren,
+    children,
+  );
+  const parentHostInstance = getInstanceFromHostFiber<Instance | Container>(
+    parentHostFiber,
+  );
 
   if (children.length === 0) {
     return compareDocumentPositionForEmptyFragment(
@@ -3390,8 +3424,10 @@ FragmentInstance.prototype.compareDocumentPosition = function (
     );
   }
 
-  const firstNode = getInstanceFromHostFiber<Instance>(children[0]);
-  const lastNode = getInstanceFromHostFiber<Instance>(
+  const firstNode = getInstanceFromHostFiber<Instance | TextInstance>(
+    children[0],
+  );
+  const lastNode = getInstanceFromHostFiber<Instance | TextInstance>(
     children[children.length - 1],
   );
 
@@ -3524,17 +3560,23 @@ if (enableFragmentRefsScrollIntoView) {
     }
     // First, get the children nodes
     const children: Array<Fiber> = [];
-    traverseFragmentInstance(this._fragmentFiber, collectChildren, children);
+    traverseFragmentInstanceHostComponentsAndTexts(
+      this._fragmentFiber,
+      collectChildren,
+      children,
+    );
 
     const resolvedAlignToTop = alignToTop !== false;
 
     // If there are no children, we can use the parent and siblings to determine a position
     if (children.length === 0) {
-      const hostSiblings = getFragmentInstanceSiblings(this._fragmentFiber);
+      const hostSiblings = getFragmentInstanceHostComponentSiblings(
+        this._fragmentFiber,
+      );
       const targetFiber = resolvedAlignToTop
         ? hostSiblings[1] ||
           hostSiblings[0] ||
-          getFragmentParentHostFiber(this._fragmentFiber)
+          getFragmentParentHostComponentOrRootFiber(this._fragmentFiber)
         : hostSiblings[0] || hostSiblings[1];
 
       if (targetFiber === null) {
@@ -3546,7 +3588,13 @@ if (enableFragmentRefsScrollIntoView) {
         }
         return;
       }
-      const target = getInstanceFromHostFiber<Instance>(targetFiber);
+      const target = getInstanceFromHostFiber<Instance | Container>(
+        targetFiber,
+      );
+      // TODO: If the parent host fiber is a HostRoot, the target is a
+      // Container which can be a Document or DocumentFragment. Those have no
+      // scrollIntoView method, so this crashes at runtime.
+      // $FlowFixMe[prop-missing]
       target.scrollIntoView(alignToTop);
       return;
     }
@@ -3579,17 +3627,16 @@ function addFragmentHandleToFiber(
   fragmentInstance: FragmentInstanceType,
 ): boolean {
   if (enableFragmentRefsInstanceHandles) {
-    const instance =
-      getInstanceFromHostFiber<InstanceWithFragmentHandles>(child);
-    if (instance != null) {
-      addFragmentHandleToInstance(instance, fragmentInstance);
-    }
+    const instance = getInstanceFromHostFiber<Instance | TextInstance>(
+      child,
+    ) as any as HostNodeWithFragmentHandles;
+    addFragmentHandleToInstance(instance, fragmentInstance);
   }
   return false;
 }
 
 function addFragmentHandleToInstance(
-  instance: InstanceWithFragmentHandles,
+  instance: HostNodeWithFragmentHandles,
   fragmentInstance: FragmentInstanceType,
 ): void {
   if (enableFragmentRefsInstanceHandles) {
@@ -3605,7 +3652,7 @@ export function createFragmentInstance(
 ): FragmentInstanceType {
   const fragmentInstance = new (FragmentInstance as any)(fragmentFiber);
   if (enableFragmentRefsInstanceHandles) {
-    traverseFragmentInstance(
+    traverseFragmentInstanceHostComponentsAndTexts(
       fragmentFiber,
       addFragmentHandleToFiber,
       fragmentInstance,

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -67,7 +67,7 @@ import {
   getInstanceFromHostFiber,
   isFiberFollowing,
   isFiberPreceding,
-  getFragmentInstanceHostComponentSiblings,
+  getFragmentInstanceHostComponentOrTextSiblings,
   traverseFragmentInstanceHostComponentsAndTextsDeeply,
   fiberIsPortaledIntoHost,
   isFiberContainedByFragment,
@@ -3546,6 +3546,19 @@ function validateDocumentPositionWithFiberTree(
   return false;
 }
 
+function scrollTextNodeIntoView(
+  textNode: TextInstance,
+  resolvedAlignToTop: boolean,
+): void {
+  const range = textNode.ownerDocument.createRange();
+  range.selectNodeContents(textNode);
+  const rect = range.getBoundingClientRect();
+  const scrollY = resolvedAlignToTop
+    ? window.scrollY + rect.top
+    : window.scrollY + rect.bottom - window.innerHeight;
+  window.scrollTo(window.scrollX + rect.left, scrollY);
+}
+
 if (enableFragmentRefsScrollIntoView) {
   // $FlowFixMe[prop-missing]
   FragmentInstance.prototype.scrollIntoView = function (
@@ -3570,7 +3583,7 @@ if (enableFragmentRefsScrollIntoView) {
 
     // If there are no children, we can use the parent and siblings to determine a position
     if (children.length === 0) {
-      const hostSiblings = getFragmentInstanceHostComponentSiblings(
+      const hostSiblings = getFragmentInstanceHostComponentOrTextSiblings(
         this._fragmentFiber,
       );
       const targetFiber = resolvedAlignToTop
@@ -3586,6 +3599,12 @@ if (enableFragmentRefsScrollIntoView) {
               'children, siblings, or parent. No scroll was performed.',
           );
         }
+        return;
+      }
+      // For text node siblings, use Range API to scroll to their position
+      if (enableFragmentRefsTextNodes && targetFiber.tag === HostText) {
+        const textNode = getInstanceFromHostFiber<TextInstance>(targetFiber);
+        scrollTextNodeIntoView(textNode, resolvedAlignToTop);
         return;
       }
       const target = getInstanceFromHostFiber<Instance | Container>(
@@ -3604,14 +3623,8 @@ if (enableFragmentRefsScrollIntoView) {
       const child = children[i];
       // For text nodes, use Range API to scroll to their position
       if (enableFragmentRefsTextNodes && child.tag === HostText) {
-        const textNode: Text = child.stateNode;
-        const range = textNode.ownerDocument.createRange();
-        range.selectNodeContents(textNode);
-        const rect = range.getBoundingClientRect();
-        const scrollY = resolvedAlignToTop
-          ? window.scrollY + rect.top
-          : window.scrollY + rect.bottom - window.innerHeight;
-        window.scrollTo(window.scrollX + rect.left, scrollY);
+        const textNode = getInstanceFromHostFiber<TextInstance>(child);
+        scrollTextNodeIntoView(textNode, resolvedAlignToTop);
         i += resolvedAlignToTop ? -1 : 1;
         continue;
       }

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -22,6 +22,7 @@ let simulateIntersection;
 let setClientRects;
 let mockRangeClientRects;
 let assertConsoleErrorDev;
+let assertConsoleWarnDev;
 
 function Wrapper({children}) {
   return children;
@@ -44,6 +45,7 @@ describe('FragmentRefs', () => {
     mockRangeClientRects = IntersectionMocks.mockRangeClientRects;
     assertConsoleErrorDev =
       require('internal-test-utils').assertConsoleErrorDev;
+    assertConsoleWarnDev = require('internal-test-utils').assertConsoleWarnDev;
 
     container = document.createElement('div');
     document.body.innerHTML = '';
@@ -2753,6 +2755,51 @@ describe('FragmentRefs', () => {
 
       window.scrollTo = originalScrollTo;
       restoreRange();
+    });
+
+    // @gate enableFragmentRefs && enableFragmentRefsTextNodes && enableFragmentRefsScrollIntoView
+    it('scrollIntoView ignores text siblings of an empty fragment', async () => {
+      const fragmentRef = React.createRef();
+      const parentRef = React.createRef();
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() =>
+        root.render(
+          <div ref={parentRef}>
+            Text before
+            <Fragment ref={fragmentRef} />
+            Text after
+          </div>,
+        ),
+      );
+
+      const parentScrollMock = jest.fn();
+      parentRef.current.scrollIntoView = parentScrollMock;
+      // Mock window.scrollTo to verify Range-based text scrolling
+      const originalScrollTo = window.scrollTo;
+      const scrollToMock = jest.fn();
+      window.scrollTo = scrollToMock;
+
+      // TODO: Text siblings should be scrolled to with the Range API like
+      // text children are. Currently they are skipped when collecting
+      // siblings, so the default call scrolls the parent element instead.
+      fragmentRef.current.scrollIntoView();
+      expect(parentScrollMock).toHaveBeenCalledTimes(1);
+      expect(scrollToMock).toHaveBeenCalledTimes(0);
+
+      // alignToTop=false has no parent fallback, so no scroll is performed
+      fragmentRef.current.scrollIntoView(false);
+      expect(parentScrollMock).toHaveBeenCalledTimes(1);
+      expect(scrollToMock).toHaveBeenCalledTimes(0);
+      assertConsoleWarnDev(
+        [
+          'You are attempting to scroll a FragmentInstance that has no ' +
+            'children, siblings, or parent. No scroll was performed.',
+        ],
+        {withoutStack: true},
+      );
+
+      window.scrollTo = originalScrollTo;
     });
 
     // @gate enableFragmentRefs

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -22,7 +22,6 @@ let simulateIntersection;
 let setClientRects;
 let mockRangeClientRects;
 let assertConsoleErrorDev;
-let assertConsoleWarnDev;
 
 function Wrapper({children}) {
   return children;
@@ -45,7 +44,6 @@ describe('FragmentRefs', () => {
     mockRangeClientRects = IntersectionMocks.mockRangeClientRects;
     assertConsoleErrorDev =
       require('internal-test-utils').assertConsoleErrorDev;
-    assertConsoleWarnDev = require('internal-test-utils').assertConsoleWarnDev;
 
     container = document.createElement('div');
     document.body.innerHTML = '';
@@ -2758,7 +2756,10 @@ describe('FragmentRefs', () => {
     });
 
     // @gate enableFragmentRefs && enableFragmentRefsTextNodes && enableFragmentRefsScrollIntoView
-    it('scrollIntoView ignores text siblings of an empty fragment', async () => {
+    it('scrollIntoView scrolls to text siblings of an empty fragment using the Range API', async () => {
+      const restoreRange = mockRangeClientRects([
+        {x: 100, y: 200, width: 80, height: 16},
+      ]);
       const fragmentRef = React.createRef();
       const parentRef = React.createRef();
       const root = ReactDOMClient.createRoot(container);
@@ -2780,26 +2781,20 @@ describe('FragmentRefs', () => {
       const scrollToMock = jest.fn();
       window.scrollTo = scrollToMock;
 
-      // TODO: Text siblings should be scrolled to with the Range API like
-      // text children are. Currently they are skipped when collecting
-      // siblings, so the default call scrolls the parent element instead.
+      // Default call scrolls to the following text sibling
       fragmentRef.current.scrollIntoView();
-      expect(parentScrollMock).toHaveBeenCalledTimes(1);
-      expect(scrollToMock).toHaveBeenCalledTimes(0);
+      expect(scrollToMock).toHaveBeenCalledTimes(1);
+      expect(parentScrollMock).toHaveBeenCalledTimes(0);
 
-      // alignToTop=false has no parent fallback, so no scroll is performed
+      scrollToMock.mockClear();
+
+      // alignToTop=false scrolls to the preceding text sibling
       fragmentRef.current.scrollIntoView(false);
-      expect(parentScrollMock).toHaveBeenCalledTimes(1);
-      expect(scrollToMock).toHaveBeenCalledTimes(0);
-      assertConsoleWarnDev(
-        [
-          'You are attempting to scroll a FragmentInstance that has no ' +
-            'children, siblings, or parent. No scroll was performed.',
-        ],
-        {withoutStack: true},
-      );
+      expect(scrollToMock).toHaveBeenCalledTimes(1);
+      expect(parentScrollMock).toHaveBeenCalledTimes(0);
 
       window.scrollTo = originalScrollTo;
+      restoreRange();
     });
 
     // @gate enableFragmentRefs

--- a/packages/react-native-renderer/src/ReactFiberConfigFabric.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigFabric.js
@@ -24,8 +24,8 @@ import {
 import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
 import {HostText} from 'react-reconciler/src/ReactWorkTags';
 import {
-  getFragmentParentHostFiber,
-  traverseFragmentInstance,
+  getFragmentParentHostComponentOrRootFiber,
+  traverseFragmentInstanceHostComponentsAndTexts,
 } from 'react-reconciler/src/ReactFiberTreeReflection';
 
 // Modules provided by RN:
@@ -704,7 +704,11 @@ FragmentInstance.prototype.observeUsing = function (
     this._observers = new Set();
   }
   this._observers.add(observer);
-  traverseFragmentInstance(this._fragmentFiber, observeChild, observer);
+  traverseFragmentInstanceHostComponentsAndTexts(
+    this._fragmentFiber,
+    observeChild,
+    observer,
+  );
 };
 function observeChild(child: Fiber, observer: IntersectionObserver) {
   // $FlowFixMe[incompatible-type]
@@ -728,7 +732,11 @@ FragmentInstance.prototype.unobserveUsing = function (
     }
   } else {
     observers.delete(observer);
-    traverseFragmentInstance(this._fragmentFiber, unobserveChild, observer);
+    traverseFragmentInstanceHostComponentsAndTexts(
+      this._fragmentFiber,
+      unobserveChild,
+      observer,
+    );
   }
 };
 function unobserveChild(child: Fiber, observer: IntersectionObserver) {
@@ -744,12 +752,18 @@ FragmentInstance.prototype.compareDocumentPosition = function (
   this: FragmentInstanceType,
   otherNode: PublicInstance,
 ): number {
-  const parentHostFiber = getFragmentParentHostFiber(this._fragmentFiber);
+  const parentHostFiber = getFragmentParentHostComponentOrRootFiber(
+    this._fragmentFiber,
+  );
   if (parentHostFiber === null) {
     return Node.DOCUMENT_POSITION_DISCONNECTED;
   }
   const children: Array<Fiber> = [];
-  traverseFragmentInstance(this._fragmentFiber, collectChildren, children);
+  traverseFragmentInstanceHostComponentsAndTexts(
+    this._fragmentFiber,
+    collectChildren,
+    children,
+  );
   if (children.length === 0) {
     const parentHostInstance = getPublicInstanceFromHostFiber(parentHostFiber);
     return compareDocumentPositionForEmptyFragment<PublicInstance>(
@@ -804,7 +818,9 @@ FragmentInstance.prototype.getRootNode = function (
   this: FragmentInstanceType,
   getRootNodeOptions?: {composed: boolean},
 ): Node | FragmentInstanceType {
-  const parentHostFiber = getFragmentParentHostFiber(this._fragmentFiber);
+  const parentHostFiber = getFragmentParentHostComponentOrRootFiber(
+    this._fragmentFiber,
+  );
   if (parentHostFiber === null) {
     return this;
   }
@@ -819,7 +835,11 @@ FragmentInstance.prototype.getClientRects = function (
   this: FragmentInstanceType,
 ): Array<DOMRect> {
   const rects: Array<DOMRect> = [];
-  traverseFragmentInstance(this._fragmentFiber, collectClientRects, rects);
+  traverseFragmentInstanceHostComponentsAndTexts(
+    this._fragmentFiber,
+    collectClientRects,
+    rects,
+  );
   return rects;
 };
 function collectClientRects(child: Fiber, rects: Array<DOMRect>): boolean {
@@ -867,7 +887,7 @@ export function createFragmentInstance(
 ): FragmentInstanceType {
   const fragmentInstance = new (FragmentInstance as any)(fragmentFiber);
   if (enableFragmentRefsInstanceHandles) {
-    traverseFragmentInstance(
+    traverseFragmentInstanceHostComponentsAndTexts(
       fragmentFiber,
       addFragmentHandleToFiber,
       fragmentInstance,

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -10,6 +10,8 @@
 import type {Fiber} from './ReactInternalTypes';
 import type {
   Container,
+  Instance,
+  TextInstance,
   ActivityInstance,
   SuspenseInstance,
 } from './ReactFiberConfig';
@@ -345,27 +347,34 @@ export function doesFiberContain(
   return false;
 }
 
-export function traverseFragmentInstance<A, B, C>(
+export function traverseFragmentInstanceHostComponentsAndTexts<A, B, C>(
   fragmentFiber: Fiber,
   fn: (Fiber, A, B, C) => boolean,
   a: A,
   b: B,
   c: C,
 ): void {
-  traverseVisibleHostChildren(fragmentFiber.child, false, fn, a, b, c);
+  traverseVisibleHostComponentsAndTexts(
+    fragmentFiber.child,
+    false,
+    fn,
+    a,
+    b,
+    c,
+  );
 }
 
-export function traverseFragmentInstanceDeeply<A, B, C>(
+export function traverseFragmentInstanceHostComponentsAndTextsDeeply<A, B, C>(
   fragmentFiber: Fiber,
   fn: (Fiber, A, B, C) => boolean,
   a: A,
   b: B,
   c: C,
 ): void {
-  traverseVisibleHostChildren(fragmentFiber.child, true, fn, a, b, c);
+  traverseVisibleHostComponentsAndTexts(fragmentFiber.child, true, fn, a, b, c);
 }
 
-function traverseVisibleHostChildren<A, B, C>(
+function traverseVisibleHostComponentsAndTexts<A, B, C>(
   child: Fiber | null,
   searchWithinHosts: boolean,
   fn: (Fiber, A, B, C) => boolean,
@@ -387,7 +396,14 @@ function traverseVisibleHostChildren<A, B, C>(
     } else {
       if (
         (searchWithinHosts || child.tag !== HostComponent) &&
-        traverseVisibleHostChildren(child.child, searchWithinHosts, fn, a, b, c)
+        traverseVisibleHostComponentsAndTexts(
+          child.child,
+          searchWithinHosts,
+          fn,
+          a,
+          b,
+          c,
+        )
       ) {
         return true;
       }
@@ -397,7 +413,9 @@ function traverseVisibleHostChildren<A, B, C>(
   return false;
 }
 
-export function getFragmentParentHostFiber(fiber: Fiber): null | Fiber {
+export function getFragmentParentHostComponentOrRootFiber(
+  fiber: Fiber,
+): null | Fiber {
   let parent = fiber.return;
   while (parent !== null) {
     if (parent.tag === HostRoot || parent.tag === HostComponent) {
@@ -424,11 +442,11 @@ export function fiberIsPortaledIntoHost(fiber: Fiber): boolean {
   return foundPortalParent;
 }
 
-export function getFragmentInstanceSiblings(
+export function getFragmentInstanceHostComponentSiblings(
   fiber: Fiber,
 ): [Fiber | null, Fiber | null] {
   const result: [Fiber | null, Fiber | null] = [null, null];
-  const parentHostFiber = getFragmentParentHostFiber(fiber);
+  const parentHostFiber = getFragmentParentHostComponentOrRootFiber(fiber);
   if (parentHostFiber === null) {
     return result;
   }
@@ -474,7 +492,9 @@ function findFragmentInstanceSiblings(
   return false;
 }
 
-export function getInstanceFromHostFiber<I>(fiber: Fiber): I {
+export function getInstanceFromHostFiber<
+  I: Instance | TextInstance | Container,
+>(fiber: Fiber): I {
   switch (fiber.tag) {
     case HostComponent:
     case HostText:
@@ -501,8 +521,10 @@ function popSearchBoundary(): null | Fiber {
   return searchBoundary;
 }
 
-export function getNextSiblingHostFiber(fiber: Fiber): null | Fiber {
-  traverseVisibleHostChildren(fiber.sibling, false, findNextSibling);
+export function getNextSiblingHostComponentOrTextFiber(
+  fiber: Fiber,
+): null | Fiber {
+  traverseVisibleHostComponentsAndTexts(fiber.sibling, false, findNextSibling);
   const sibling = popSearchTarget();
   pushSearchTarget(null);
   return sibling;
@@ -536,7 +558,7 @@ export function isFragmentContainedByFiber(
 ): boolean {
   let current: Fiber | null = fragmentFiber;
   const fiberHostParent: Fiber | null =
-    getFragmentParentHostFiber(fragmentFiber);
+    getFragmentParentHostComponentOrRootFiber(fragmentFiber);
   while (current !== null) {
     if (
       (current.tag === HostComponent || current.tag === HostRoot) &&
@@ -558,7 +580,7 @@ export function isFiberPreceding(fiber: Fiber, otherFiber: Fiber): boolean {
   if (commonAncestor === null) {
     return false;
   }
-  traverseVisibleHostChildren(
+  traverseVisibleHostComponentsAndTexts(
     commonAncestor,
     true,
     isFiberPrecedingCheck,
@@ -594,7 +616,7 @@ export function isFiberFollowing(fiber: Fiber, otherFiber: Fiber): boolean {
   if (commonAncestor === null) {
     return false;
   }
-  traverseVisibleHostChildren(
+  traverseVisibleHostComponentsAndTexts(
     commonAncestor,
     true,
     isFiberFollowingCheck,

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -442,7 +442,7 @@ export function fiberIsPortaledIntoHost(fiber: Fiber): boolean {
   return foundPortalParent;
 }
 
-export function getFragmentInstanceHostComponentSiblings(
+export function getFragmentInstanceHostComponentOrTextSiblings(
   fiber: Fiber,
 ): [Fiber | null, Fiber | null] {
   const result: [Fiber | null, Fiber | null] = [null, null];
@@ -451,11 +451,15 @@ export function getFragmentInstanceHostComponentSiblings(
     return result;
   }
 
-  findFragmentInstanceSiblings(result, fiber, parentHostFiber.child);
+  findFragmentInstanceHostComponentOrTextSiblings(
+    result,
+    fiber,
+    parentHostFiber.child,
+  );
   return result;
 }
 
-function findFragmentInstanceSiblings(
+function findFragmentInstanceHostComponentOrTextSiblings(
   result: [Fiber | null, Fiber | null],
   self: Fiber,
   child: null | Fiber,
@@ -470,7 +474,10 @@ function findFragmentInstanceSiblings(
         return true;
       }
     }
-    if (child.tag === HostComponent) {
+    if (
+      child.tag === HostComponent ||
+      (enableFragmentRefsTextNodes && child.tag === HostText)
+    ) {
       if (foundSelf) {
         result[1] = child;
         return true;
@@ -483,7 +490,14 @@ function findFragmentInstanceSiblings(
     ) {
       // Skip hidden subtrees
     } else {
-      if (findFragmentInstanceSiblings(result, self, child.child, foundSelf)) {
+      if (
+        findFragmentInstanceHostComponentOrTextSiblings(
+          result,
+          self,
+          child.child,
+          foundSelf,
+        )
+      ) {
         return true;
       }
     }

--- a/packages/shared/ReactDOMFragmentRefShared.js
+++ b/packages/shared/ReactDOMFragmentRefShared.js
@@ -11,7 +11,7 @@
 
 import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
 
-import {getNextSiblingHostFiber} from 'react-reconciler/src/ReactFiberTreeReflection';
+import {getNextSiblingHostComponentOrTextFiber} from 'react-reconciler/src/ReactFiberTreeReflection';
 
 export function compareDocumentPositionForEmptyFragment<TPublicInstance>(
   fragmentFiber: Fiber,
@@ -32,7 +32,8 @@ export function compareDocumentPositionForEmptyFragment<TPublicInstance>(
     if (parentResult & Node.DOCUMENT_POSITION_CONTAINED_BY) {
       // otherNode is one of the fragment's siblings. Use the next
       // sibling to determine if its preceding or following.
-      const nextSiblingFiber = getNextSiblingHostFiber(fragmentFiber);
+      const nextSiblingFiber =
+        getNextSiblingHostComponentOrTextFiber(fragmentFiber);
       if (nextSiblingFiber === null) {
         result = Node.DOCUMENT_POSITION_PRECEDING;
       } else {


### PR DESCRIPTION
`getInstanceFromHostFiber` returns a different kind of instance depending on the fiber tag: an `Instance` for HostComponent, a `TextInstance` for HostText, and a `Container` for HostRoot. The generic was unconstrained and every callsite instantiated it as `<Instance>`, which is unsound whenever the passed fiber is not guaranteed to be a HostComponent.

This change bounds the generic as `<I: Instance | TextInstance | Container>` and makes the callsites honest. The fragment traversal helpers now carry the fiber tags they can yield in their names (`traverseFragmentInstanceHostComponentsAndTexts`, `getFragmentParentHostComponentOrRootFiber`, `getNextSiblingHostComponentOrTextFiber`, `getFragmentInstanceHostComponentOrTextSiblings`), so each callsite can instantiate the generic with the union that actually matches what it passes in: `<Instance>` only where a preceding HostText guard leaves HostComponent, `<Instance | TextInstance>` for traversal children, and `<Instance | Container>` for parent host fibers.

The honest types revealed a real bug in `FragmentInstance.prototype.scrollIntoView`. An empty fragment with only text node siblings scrolled the parent host instance on the default call and performed no scroll at all with `alignToTop=false`, because the sibling search only collected HostComponent fibers. The sibling search now also collects HostText fibers when `enableFragmentRefsTextNodes` is enabled, and text targets are scrolled with the Range API through a shared `scrollTextNodeIntoView` helper, matching how text children were already handled. A test documenting the broken behavior lands one commit before the fix flips its assertions.

One revealed bug is intentionally left unfixed here: when the empty-fragment fallback resolves to the HostRoot, the target is a `Container` that can be a `Document` or `ShadowRoot`, which have no `scrollIntoView` method and crash at runtime with `getInstanceFromHostFiber(...).scrollIntoView is not a function`. This is reachable in full-document apps because the parent lookup also skips HostSingleton fibers (`<html>`, `<body>`). That callsite carries a TODO with a targeted suppression, and handling singletons plus the container fallback is planned as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)